### PR TITLE
Added Fragment Cell to Compare Storybook

### DIFF
--- a/web/src/components/Chat/Chat.tsx
+++ b/web/src/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import ChatCell from '../ChatCell'
+import ChatCell from 'src/components/ChatCell'
 
 const Chat = () => {
   return <ChatCell chatRoomId="1" />

--- a/web/src/components/ChatCell/ChatCell.mock.ts
+++ b/web/src/components/ChatCell/ChatCell.mock.ts
@@ -1,4 +1,4 @@
-import { ChatMessageFragment } from 'types/graphql'
+import { ChatMessage } from 'types/graphql'
 
 // Define your own mock data here:
 export const standard = (/* vars, { ctx, req } */) => ({
@@ -10,5 +10,6 @@ export const standard = (/* vars, { ctx, req } */) => ({
       displayName: `User ${(index % 5) + 1}`, // Cycle through 5 different users
       id: (index % 5) + 1,
     },
-  })) satisfies ChatMessageFragment[],
+    chatRoomId: '42',
+  })) satisfies ChatMessage[],
 })

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.mock.ts
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.mock.ts
@@ -1,0 +1,14 @@
+import { ChatMessageFragment } from 'types/graphql'
+
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  chatMessages: Array.from({ length: 20 }, (_, index) => ({
+    body: `Message with Fragment ${index + 7}`,
+    createdAt: '2024-05-01T00:00:00.000Z',
+    id: index + 1,
+    user: {
+      displayName: `User for Fragment ${(index % 5) + 7}`, // Cycle through 5 different users
+      id: (index % 5) + 7,
+    },
+  })) satisfies ChatMessageFragment[],
+})

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.mock.ts
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.mock.ts
@@ -1,7 +1,7 @@
 import { ChatMessageFragment } from 'types/graphql'
 
 // Define your own mock data here:
-export const standard = (/* vars, { ctx, req } */) => ({
+export const standardWithFragments = (/* vars, { ctx, req } */) => ({
   chatMessages: Array.from({ length: 20 }, (_, index) => ({
     body: `Message with Fragment ${index + 7}`,
     createdAt: '2024-05-01T00:00:00.000Z',

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.stories.tsx
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.stories.tsx
@@ -1,0 +1,55 @@
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
+import { MockSubscriptionLink } from '@apollo/client/testing'
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+
+import { Failure, Loading, Success } from './ChatFragmentCell'
+import { standard } from './ChatFragmentCell.mock'
+
+const meta: Meta = {
+  title: 'Cells/Chat/ChatFragmentMessagesCell',
+  tags: ['autodocs'],
+}
+
+export default meta
+
+const subscriptionDecorator: Decorator = (Story) => {
+  const link = new MockSubscriptionLink()
+  const client = new ApolloClient({
+    link,
+    cache: new InMemoryCache({ addTypename: false }),
+  })
+
+  return (
+    <ApolloProvider client={client}>
+      <Story />
+    </ApolloProvider>
+  )
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  },
+  decorators: [subscriptionDecorator],
+}
+
+export const loading: StoryObj<typeof Loading> = {
+  render: () => {
+    return Loading ? <Loading /> : <></>
+  },
+}
+
+export const empty: StoryObj<typeof Success> = {
+  args: {
+    chatMessages: [],
+  },
+  render: (args) => {
+    return Success ? <Success {...args} /> : <></>
+  },
+}
+
+export const failure: StoryObj<typeof Failure> = {
+  render: (args) => {
+    return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+  },
+}

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.stories.tsx
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.stories.tsx
@@ -3,7 +3,7 @@ import { MockSubscriptionLink } from '@apollo/client/testing'
 import type { Decorator, Meta, StoryObj } from '@storybook/react'
 
 import { Failure, Loading, Success } from './ChatFragmentCell'
-import { standard } from './ChatFragmentCell.mock'
+import { standardWithFragments } from './ChatFragmentCell.mock'
 
 const meta: Meta = {
   title: 'Cells/Chat/ChatFragmentMessagesCell',
@@ -28,7 +28,7 @@ const subscriptionDecorator: Decorator = (Story) => {
 
 export const success: StoryObj<typeof Success> = {
   render: (args) => {
-    return Success ? <Success {...standard()} {...args} /> : <></>
+    return Success ? <Success {...standardWithFragments()} {...args} /> : <></>
   },
   decorators: [subscriptionDecorator],
 }

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.test.tsx
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@redwoodjs/testing/web'
+
+import { Loading, Empty, Failure, Success } from './ChatFragmentCell'
+import { standard } from './ChatFragmentCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('ChatCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success chat={standard().chat} />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ChatFragmentCell/ChatFragmentCell.tsx
+++ b/web/src/components/ChatFragmentCell/ChatFragmentCell.tsx
@@ -15,24 +15,30 @@ import {
   type CellSuccessProps,
   type TypedDocumentNode,
 } from '@redwoodjs/web'
-// import { registerFragment } from '@redwoodjs/web/apollo'
+import { registerFragment } from '@redwoodjs/web/apollo'
 
 export type ChatMessagesCellProps = Pick<ChatMessageInput, 'chatRoomId'>
 
-// COMMENT THIS TO TEST FRAGMENT. THEN GO STORYBOOK > COMPONENTS > CHAT
+registerFragment(gql`
+  fragment ChatMessageFragment on ChatMessage {
+    id
+    body
+    createdAt
+    user {
+      id
+      displayName
+    }
+  }
+`)
+
+// UMCOMMENT THIS TO TEST FRAGMENT
 export const QUERY: TypedDocumentNode<
   ChatMessagesQuery,
   ChatMessagesQueryVariables
 > = gql`
   query ChatMessagesQuery($chatRoomId: String!) {
     chatMessages(chatRoomId: $chatRoomId) {
-      id
-      body
-      createdAt
-      user {
-        id
-        displayName
-      }
+      ...ChatMessageFragment
     }
   }
 `
@@ -107,10 +113,10 @@ export const Success = ({
 
   return (
     <>
-      REMOVED REALTIME FOR SIMPLER REPRO (F5)
+      REMOVED REALTIME FOR SIMPLER REPRO (F5 fragment) - with fragments
       {messages.length === 0 && (
         <div className="grid h-full place-content-center place-items-center gap-2">
-          {`It's so empty here`}
+          {`It's so empty here -- with fragments`}
         </div>
       )}
       <div className="flex flex-col-reverse overflow-auto p-3">
@@ -120,8 +126,12 @@ export const Success = ({
               key={item.id}
               className="animate-appearance-in text-small flex w-full flex-wrap gap-1"
             >
-              <span className="inline-flex h-6">{item.user.displayName}:</span>
-              <span className="[word-break:break-word]">{item.body}</span>
+              <span className="inline-flex h-6">
+                {item.user.displayName} fragment cell:
+              </span>
+              <span className="[word-break:break-word]">
+                {item.body} -- fragment cell
+              </span>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
I added a separate cell that uses the fragment to make comparing the two cells easier:

* ChatCell -> ChatMessagesCell story

![image](https://github.com/irg1008/issue-redwood-fragments-storybook/assets/1051633/6d7de115-7804-498e-8d74-27c787c42ffc)

* ChatFragmentCell -> ChatMessagesFragmentCell story

![image](https://github.com/irg1008/issue-redwood-fragments-storybook/assets/1051633/4433f70d-252c-4428-bf10-367e1cb9f26c)


Can see that the cells themselves respect the different mock data and the fragment.

That said, the `Chat` component that uses one of the cells:

With `ChatCell`:

![image](https://github.com/irg1008/issue-redwood-fragments-storybook/assets/1051633/69751d97-fc11-41a3-bd0e-a93222788df3)


With `ChatFragmentCell`

![image](https://github.com/irg1008/issue-redwood-fragments-storybook/assets/1051633/c94e3f4d-786a-42bc-b64a-a77e8939b857)

So it appears the cell mock is ok (I believe) but when the mocked cell is used in a component then mocked data isn't complete?

Have to investigate more.